### PR TITLE
- [NOTICE] Add TYPO3 13.4 version in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
 		{
 			"name": "Wolfgang Höller",
 			"role": "Developer"
-		
+
 		}
 	],
 	"license": [
 		"GPL-2.0-or-later"
 	],
 	"require": {
-		"typo3/cms-rte-ckeditor": "^12.4"
+		"typo3/cms-rte-ckeditor": "^12.4 || ^13.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,11 +7,11 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => true,
     'author' => 'Georg Ringer',
     'author_email' => 'gr@studiomitte.com',
-    'version' => '1.0.3',
+    'version' => '1.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-12.4.99',
-            'rte_ckeditor' => '12.4.0-12.4.99'
+            'typo3' => '12.4.0-13.4.99',
+            'rte_ckeditor' => '12.4.0-13.4.99'
         ],
     ],
 ];


### PR DESCRIPTION
No code changes, simply add 13.4 to dependencies. It works at least in my TYPO3 13.4 project.